### PR TITLE
custom truncate length in ml-facets

### DIFF
--- a/src/directives/ml-facets.directive.js
+++ b/src/directives/ml-facets.directive.js
@@ -11,6 +11,7 @@
    * - `toggle`: a reference to a function that will select or clear facets based on their state. Invoked with `facet` (name) and `value` parameters. This function should invoke `mlSearch.toggleFacet(facetName, value).search()`
    * - `showMore`: a reference to a function that will pull down the next five facets. This is invoked with the `facet` itself and the `facetName`. This function should by default invoke `mlSearch.showMoreFacets(facet, facetName)`
    * - `template`: optional. A URL referencing a template to be used with the directive. If empty, the default bootstrap template will be used (chiclet-style facets). If `"inline"`, a bootstrap/font-awesome template will be used (inline facet selections)
+   * - `truncate`: optional. The length at which to truncate the facet display. Defaults to `20`.
    *
    * Example:
    *
@@ -30,7 +31,8 @@
         toggle: '&',
         showMore: '&'
       },
-      templateUrl: template
+      templateUrl: template,
+      link: link
     };
   }
 
@@ -49,6 +51,10 @@
     }
 
     return url;
+  }
+
+  function link($scope, element, attrs) {
+    $scope.truncateLength = parseInt(attrs.truncate) || 20;
   }
 
 }());

--- a/src/ml-search.js
+++ b/src/ml-search.js
@@ -20,22 +20,11 @@
   function truncate() {
     return function (text, length, end) {
       length = length || 10;
-      // if (isNaN(length)) {
-      //   length = 10;
-      // }
-
       end = end || '...';
-      // if (end === undefined) {
-      //   end = '...';
-      // }
 
-      if (text.length <= length || text.length - end.length <= length) {
-        return text;
-      }
-      else {
-        return String(text).substring(0, length - end.length) + end;
-      }
-
+      return (text.length > length) ?
+             String(text).substring(0, length - end.length) + end :
+             text;
     };
   }
 

--- a/src/templates/ml-facets-inline.html
+++ b/src/templates/ml-facets-inline.html
@@ -4,8 +4,10 @@
     <div ng-repeat="value in facet.facetValues" ng-class="{ 'on': value.selected} ">
       <a ng-click="toggle({facet: facet.__key, value: value.name})" title="{{ value.name }}">
         <i ng-class="{ 'fa fa-trash-o': value.selected }"></i>
-        {{ value.name | truncate:truncateLength }} ({{ value.count }})
+        <span ng-if="value.name">{{ value.name | truncate:truncateLength }}</span>
+        <em ng-if="!value.name">blank</em>
       </a>
+      <span>({{ value.count }})</span>
     </div>
     <div ng-if="!facet.displayingAll">
       <a href ng-click="showMore({facet: facet, facetName: facet.__key})">see more ...</a>

--- a/src/templates/ml-facets-inline.html
+++ b/src/templates/ml-facets-inline.html
@@ -4,7 +4,7 @@
     <div ng-repeat="value in facet.facetValues" ng-class="{ 'on': value.selected} ">
       <a ng-click="toggle({facet: facet.__key, value: value.name})" title="{{ value.name }}">
         <i ng-class="{ 'fa fa-trash-o': value.selected }"></i>
-        {{ value.name | truncate:20 }} ({{ value.count }})
+        {{ value.name | truncate:truncateLength }} ({{ value.count }})
       </a>
     </div>
     <div ng-if="!facet.displayingAll">

--- a/src/templates/ml-facets.html
+++ b/src/templates/ml-facets.html
@@ -11,8 +11,10 @@
     <h3>{{ facet.__key }}</h3>
     <div ng-repeat="value in facet.facetValues">
       <a ng-click="toggle({facet: facet.__key, value: value.name})" title="{{ value.name }}">
-        {{ value.name | truncate:truncateLength }} ({{ value.count }})
+        <span ng-if="value.name">{{ value.name | truncate:truncateLength }}</span>
+        <em ng-if="!value.name">blank</em>
       </a>
+      <span>({{ value.count }})</span>
     </div>
     <div ng-if="!facet.displayingAll">
       <a href ng-click="showMore({facet: facet, facetName: facet.__key})">see more ...</a>

--- a/src/templates/ml-facets.html
+++ b/src/templates/ml-facets.html
@@ -2,7 +2,7 @@
   <div class="chiclets">
     <div ng-repeat="(index, facet) in facets | object2Array | filter:{selected: true}">
       <div class="btn btn-primary" ng-repeat="value in facet.facetValues | filter:{selected: true}">
-        <span title="{{ value.name }}">{{ facet.__key }}: {{ value.name | truncate:20 }}</span>
+        <span title="{{ value.name }}">{{ facet.__key }}: {{ value.name | truncate:truncateLength }}</span>
         <span class="glyphicon glyphicon-remove-circle icon-white" ng-click="toggle({facet: facet.__key, value: value.name})"></span>
       </div>
     </div>
@@ -11,7 +11,7 @@
     <h3>{{ facet.__key }}</h3>
     <div ng-repeat="value in facet.facetValues">
       <a ng-click="toggle({facet: facet.__key, value: value.name})" title="{{ value.name }}">
-        {{ value.name | truncate:20 }} ({{ value.count }})
+        {{ value.name | truncate:truncateLength }} ({{ value.count }})
       </a>
     </div>
     <div ng-if="!facet.displayingAll">


### PR DESCRIPTION
adds truncate attribute to `ml-facets` directive, to support custom truncation lengths (closes #16)
fixes bounds checking in truncate filter (closes #22)
moves facet counts out of facet links (re #24)

/cc @paxtonhare 