### PR TITLE
updates and refactors query-builder usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "angular": "^1.4.1",
     "lodash": ">= 2.4.x",
-    "ml-common-ng": "^0.0.6"
+    "ml-common-ng": ">= 0.1.1"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.1",

--- a/test/spec/ml-search.service.js
+++ b/test/spec/ml-search.service.js
@@ -164,10 +164,17 @@ describe('MLSearchContext', function () {
       expect(mlSearch.setText('test').getText()).toEqual('test');
       expect(mlSearch.setText('').getText()).toBeNull();
 
-      expect(mlSearch.getQuery().query.queries[0]['and-query'].queries.length).toEqual(0);
+      var combined = null;
+      mlSearch.getCombinedQuery().then(function(c) { combined = c; });
+      $rootScope.$digest();
+
+      expect(combined.search.qtext).toBe(null);
       expect(mlSearch.setText('test')).toBe(mlSearch);
-      expect(mlSearch.getQuery().query.queries[0]['and-query'].queries.length).toEqual(2);
-      expect(mlSearch.getQuery().query.queries[0]['and-query'].queries[1].qtext).toEqual('test');
+
+      mlSearch.getCombinedQuery().then(function(c) { combined = c; });
+      $rootScope.$digest();
+
+      expect(combined.search.qtext).toEqual('test');
     });
 
     it('gets the query text', function() {
@@ -257,10 +264,10 @@ describe('MLSearchContext', function () {
 
     it('should include properties query', function() {
       var mlSearch = factory.newContext();
-      expect( JSON.stringify(mlSearch.getQuery()).match(/properties-query/) ).toBeNull();
+      expect( JSON.stringify(mlSearch.getQuery()).match(/properties-fragment-query/) ).toBeNull();
 
       mlSearch = factory.newContext({ includeProperties: true });
-      expect( JSON.stringify(mlSearch.getQuery()).match(/properties-query/) ).not.toBeNull();
+      expect( JSON.stringify(mlSearch.getQuery()).match(/properties-fragment-query/) ).not.toBeNull();
     });
 
     it('gets URL params config', function() {
@@ -1132,7 +1139,7 @@ describe('MLSearchContext', function () {
       expect(search.getSort()).toEqual('backwards');
       expect(search.getPage()).toEqual(4);
       expect(search.getActiveFacets()['my-facet'].values[0].value).toEqual('facetvalue');
-      expect(search.getQuery().query.queries[0]['and-query'].queries.length).toEqual(2);
+      expect(search.getQuery().query.queries[0]['and-query'].queries.length).toEqual(1);
 
       search.clearAllFacets();
       expect(search.getActiveFacets()['my-facet']).toBeUndefined();

--- a/test/spec/ml-search.service.js
+++ b/test/spec/ml-search.service.js
@@ -164,15 +164,12 @@ describe('MLSearchContext', function () {
       expect(mlSearch.setText('test').getText()).toEqual('test');
       expect(mlSearch.setText('').getText()).toBeNull();
 
-      var combined = null;
-      mlSearch.getCombinedQuery().then(function(c) { combined = c; });
-      $rootScope.$digest();
+      var combined = mlSearch.getCombinedQuerySync();
 
       expect(combined.search.qtext).toBe(null);
       expect(mlSearch.setText('test')).toBe(mlSearch);
 
-      mlSearch.getCombinedQuery().then(function(c) { combined = c; });
-      $rootScope.$digest();
+      combined = mlSearch.getCombinedQuerySync();
 
       expect(combined.search.qtext).toEqual('test');
     });
@@ -961,8 +958,14 @@ describe('MLSearchContext', function () {
       search.getCombinedQuery(true).then(function(response) { actual = response; });
       $httpBackend.flush();
 
-      expect( actual.search.query ).toEqual( search.getQuery() );
+      expect( actual.search.query ).toEqual( search.getQuery().query );
       expect( actual.search.options ).toEqual( mockOptionsGrammer.options );
+
+      search.getCombinedQuery(false).then(function(response) { actual = response; });
+      $rootScope.$digest();
+
+      expect( actual.search.query ).toEqual( search.getQuery().query );
+      expect( actual.search.options ).toBe(undefined);
 
       search.storedOptions = {};
       $httpBackend


### PR DESCRIPTION
updates to the latest ml-common-ng version, in order to use the new query-builder API. This PR removes all calls to deprecated qb methods, for forward compatibility as the query-builder evolves.

Additionally, refactors and simplifies combined query usage.

re #26 