### PR TITLE
custom labels for ml-results

### DIFF
--- a/src/directives/ml-results.directive.js
+++ b/src/directives/ml-results.directive.js
@@ -28,7 +28,8 @@
       restrict: 'E',
       scope: {
         results: '=',
-        link: '&'
+        link: '&',
+        label: '&'
       },
       templateUrl: template,
       link: link
@@ -49,16 +50,25 @@
 
   function link(scope, element, attrs) {
     //default link fn
-    if (!attrs.link) {
+    if ( !attrs.link ) {
       scope.link = function(result) {
-        //weird object hierarchy because directive methods requiring objects (?)
+        // directive methods require objects
         return '/detail?uri=' + encodeURIComponent( result.result.uri );
+      };
+    }
+
+    //default label fn
+    if ( !attrs.label ) {
+      scope.label = function(result) {
+        // directive methods require objects
+        return _.last( result.result.uri.split('/') );
       };
     }
 
     scope.$watch('results', function(newVal, oldVal) {
       _.each(newVal, function(result) {
         result.link = scope.link({ result: result });
+        result.label = scope.label({ result: result });
       });
     });
   }

--- a/src/templates/ml-results.html
+++ b/src/templates/ml-results.html
@@ -1,6 +1,6 @@
 <div ng-repeat="result in results">
   <h4>
-    <a ng-href="{{ result.link }}">{{ result.uri }}</a>
+    <a ng-href="{{ result.link }}">{{ result.label || result.uri }}</a>
   </h4>
   <div class="matches">
     <div class="match" ng-repeat="match in result.matches">

--- a/test/spec/directives/ml-results.directive.js
+++ b/test/spec/directives/ml-results.directive.js
@@ -45,6 +45,18 @@ describe('ml-results', function () {
         expect( result.link ).toEqual( '/detail?uri=' + encodeURIComponent( result.uri ) );
       });
     });
+
+    it('should create a default label property', function() {
+      _.each(results, function(result) {
+        expect( result.label ).toBeDefined;
+        expect( result.label ).toEqual( result.uri.split('/')[2] );
+      });
+    });
+
+    it('should use label as title', function() {
+      expect(elem.find('h4 a')[0].innerHTML).toEqual('doc1.xml');
+    });
+
   });
 
   describe('#link-function', function () {
@@ -60,6 +72,26 @@ describe('ml-results', function () {
     it('should call custom link function', function() {
       expect( $scope.linkTarget ).toHaveBeenCalled();
       expect( $scope.linkTarget.calls.count() ).toEqual( results.length );
+    });
+  });
+
+  describe('#label-function', function () {
+
+    beforeEach(function() {
+      $scope.label = jasmine.createSpy('label');
+
+      elem = angular.element('<ml-results results="results" label="label(result)"></ml-results>');
+      $compile(elem)($scope);
+      $scope.$digest();
+    });
+
+    it('should call custom label function', function() {
+      expect( $scope.label ).toHaveBeenCalled();
+      expect( $scope.label.calls.count() ).toEqual( results.length );
+    });
+
+    it('should use URI as title if label is falsy', function() {
+      expect(elem.find('h4 a')[0].innerHTML).toEqual('/docs/doc1.xml');
     });
   });
 


### PR DESCRIPTION
Adds implementation and tests for a custom `label()` method to the `ml-results` directive. Defaults to filename portion of result URI. If label is falsy, falls back to URI.

closes #76 
