### PR TITLE
Replace deprecated lodash functions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "angular": "^1.4.1",
-    "lodash": ">= 2.4.x < 4",
+    "lodash": ">= 3.0.1 < 5",
     "ml-common-ng": ">= 0.1.1"
   },
   "devDependencies": {

--- a/src/ml-remote-input.service.js
+++ b/src/ml-remote-input.service.js
@@ -134,7 +134,7 @@
         return null;
       }
 
-      matches = _.where($route.routes, { controller: searchCtrl });
+      matches = _.filter($route.routes, { controller: searchCtrl });
 
       if ( matches.length === 0 ) {
         // TODO: get route from attr, or throw Error('can\t find Search controller') ?

--- a/src/ml-search.service.js
+++ b/src/ml-search.service.js
@@ -169,7 +169,7 @@
           }
         })
         .compact()
-        .first()
+        .head()
         .value();
     },
 
@@ -196,7 +196,7 @@
      */
     setNamespaces: function setNamespaces(namespaces) {
       // TODO: this.clearNamespaces() first?
-      _.each(namespaces, this.addNamespace, this);
+      _.each(namespaces, _.bind(this.addNamespace, this));
       return this;
     },
 
@@ -1072,7 +1072,7 @@
 
       if ( storedOptions ) {
         config = _.chain( storedOptions.options.constraint )
-          .where({ name: name })
+          .filter({ name: name })
           .first()
           .clone()
           .value();
@@ -1391,7 +1391,7 @@
               'xs:decimal'
             ];
 
-            if ( _.contains(numberTypes, facetType) ) {
+            if ( _.includes(numberTypes, facetType) ) {
               newOptions.values.aggregate = newOptions.values.aggregate.concat([
                 { apply: 'sum' },
                 { apply: 'avg' }
@@ -1434,7 +1434,7 @@
           metadata;
 
       if ( _.isArray(result) ) {
-        _.each(result, this.transformMetadata, self);
+        _.each(result, _.bind(this.transformMetadata, self));
         return;
       }
 
@@ -1515,7 +1515,7 @@
 
   function getConstraint(storedOptions, name) {
     return storedOptions && storedOptions.options && storedOptions.options.constraint &&
-           _.where(asArray(storedOptions.options.constraint), { name: name })[0];
+           _.filter(asArray(storedOptions.options.constraint), { name: name })[0];
   }
 
   function valueOptionsFromConstraint(constraint) {


### PR DESCRIPTION
See https://github.com/lodash/lodash/wiki/Deprecations

I discovered this when trying to "See more" facets on a project using
Lodash 4.x and got an error (`_.where is not a function`). I believe these lodash changes are backward-compatible (they
just removed one of the aliases)